### PR TITLE
feat: interactive escrow transaction tracker with state-driven animat…

### DIFF
--- a/src/app/dashboard/orders/page.tsx
+++ b/src/app/dashboard/orders/page.tsx
@@ -1,0 +1,16 @@
+import OrderDetails from "@/components/escrow/OrderDetails";
+
+export default function OrdersPage() {
+  return (
+    <main className="min-h-screen pt-32 pb-20 px-6 bg-[#050505] text-white">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-12">
+          <h1 className="text-4xl md:text-5xl font-black tracking-tighter mb-4">Order Details</h1>
+          <p className="text-neutral-400">Track the state of your escrowed transaction in real-time.</p>
+        </div>
+
+        <OrderDetails />
+      </div>
+    </main>
+  );
+}

--- a/src/components/escrow/ConfettiSuccess.tsx
+++ b/src/components/escrow/ConfettiSuccess.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ConfettiPiece {
+  id: number;
+  x: number;
+  y: number;
+  rotation: number;
+  color: string;
+  size: number;
+  delay: number;
+}
+
+const COLORS = ["#3b82f6", "#8b5cf6", "#06b6d4", "#22c55e", "#f59e0b", "#ec4899", "#ffffff"];
+
+export default function ConfettiSuccess({ show, onClose }: { show: boolean; onClose: () => void }) {
+  const [pieces, setPieces] = useState<ConfettiPiece[]>([]);
+
+  const generatePieces = useCallback(() => {
+    return Array.from({ length: 80 }, (_, i) => ({
+      id: i,
+      x: Math.random() * 100,
+      y: -(Math.random() * 20 + 10),
+      rotation: Math.random() * 720 - 360,
+      color: COLORS[Math.floor(Math.random() * COLORS.length)],
+      size: Math.random() * 8 + 4,
+      delay: Math.random() * 0.5,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (show) {
+      setPieces(generatePieces());
+      const timer = setTimeout(onClose, 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [show, generatePieces, onClose]);
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[100] pointer-events-none overflow-hidden"
+        >
+          {pieces.map((piece) => (
+            <motion.div
+              key={piece.id}
+              initial={{
+                x: `${piece.x}vw`,
+                y: `${piece.y}vh`,
+                rotate: 0,
+                opacity: 1,
+              }}
+              animate={{
+                y: "110vh",
+                rotate: piece.rotation,
+                opacity: [1, 1, 0.8, 0],
+              }}
+              transition={{
+                duration: 2.5 + Math.random(),
+                delay: piece.delay,
+                ease: [0.25, 0.46, 0.45, 0.94],
+              }}
+              className="absolute"
+              style={{
+                width: piece.size,
+                height: piece.size * 1.5,
+                backgroundColor: piece.color,
+                borderRadius: Math.random() > 0.5 ? "50%" : "2px",
+              }}
+            />
+          ))}
+
+          {/* Center success text */}
+          <motion.div
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 200, damping: 15, delay: 0.2 }}
+            className="absolute inset-0 flex items-center justify-center pointer-events-none"
+          >
+            <div className="bg-black/80 backdrop-blur-xl border border-white/20 rounded-3xl px-12 py-10 text-center shadow-2xl">
+              <div className="text-6xl mb-4">🎉</div>
+              <h2 className="text-3xl font-black text-white mb-2">Funds Released!</h2>
+              <p className="text-neutral-400">The escrow has been completed successfully.</p>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/escrow/CountdownTimer.tsx
+++ b/src/components/escrow/CountdownTimer.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Timer } from "lucide-react";
+
+interface CountdownTimerProps {
+  targetDate: string;
+  label: string;
+}
+
+export default function CountdownTimer({ targetDate, label }: CountdownTimerProps) {
+  const [timeLeft, setTimeLeft] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0 });
+  const [isExpired, setIsExpired] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = new Date().getTime();
+      const target = new Date(targetDate).getTime();
+      const diff = target - now;
+
+      if (diff <= 0) {
+        setIsExpired(true);
+        clearInterval(interval);
+        return;
+      }
+
+      setTimeLeft({
+        days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+        hours: Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
+        minutes: Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60)),
+        seconds: Math.floor((diff % (1000 * 60)) / 1000),
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [targetDate]);
+
+  if (isExpired) {
+    return (
+      <div className="flex items-center gap-2 text-yellow-500 text-sm font-bold">
+        <Timer className="w-4 h-4" /> {label}: Expired
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-neutral-400 text-xs font-bold uppercase tracking-wider">
+        <Timer className="w-4 h-4 text-blue-400" /> {label}
+      </div>
+      <div className="flex gap-3">
+        {Object.entries(timeLeft).map(([unit, value]) => (
+          <div key={unit} className="flex flex-col items-center">
+            <div className="w-14 h-14 bg-black/60 border border-white/10 rounded-xl flex items-center justify-center text-xl font-black text-white tabular-nums">
+              {String(value).padStart(2, "0")}
+            </div>
+            <span className="text-[10px] text-neutral-500 uppercase mt-1 font-bold">{unit}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/escrow/EventLog.tsx
+++ b/src/components/escrow/EventLog.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { EscrowEvent } from "@/lib/escrowData";
+import { User, Bot, ShoppingBag } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface EventLogProps {
+  events: EscrowEvent[];
+}
+
+export default function EventLog({ events }: EventLogProps) {
+  const actorIcon = (actor: EscrowEvent["actor"]) => {
+    switch (actor) {
+      case "buyer": return <User className="w-4 h-4" />;
+      case "seller": return <ShoppingBag className="w-4 h-4" />;
+      case "system": return <Bot className="w-4 h-4" />;
+    }
+  };
+
+  const actorColor = (actor: EscrowEvent["actor"]) => {
+    switch (actor) {
+      case "buyer": return "text-cyan-400 bg-cyan-500/10 border-cyan-500/20";
+      case "seller": return "text-purple-400 bg-purple-500/10 border-purple-500/20";
+      case "system": return "text-neutral-400 bg-white/5 border-white/10";
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest">Transaction Log</h3>
+      <div className="space-y-3">
+        {events.map((event, index) => (
+          <motion.div
+            key={event.id}
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: index * 0.1, duration: 0.4 }}
+            className="flex gap-4 items-start"
+          >
+            <div className={cn(
+              "w-8 h-8 rounded-full border flex items-center justify-center shrink-0",
+              actorColor(event.actor)
+            )}>
+              {actorIcon(event.actor)}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-bold text-white">{event.label}</span>
+                <span className="text-[10px] text-neutral-600 font-mono whitespace-nowrap">
+                  {new Date(event.timestamp).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-xs text-neutral-400 mt-0.5 leading-relaxed">{event.description}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/escrow/OrderDetails.tsx
+++ b/src/components/escrow/OrderDetails.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import {
+  CheckCircle2,
+  AlertTriangle,
+  Send,
+  Wallet,
+  ShieldAlert,
+  ArrowRight,
+} from "lucide-react";
+import { EscrowState, EscrowTransaction, mockTransaction, ESCROW_STATES } from "@/lib/escrowData";
+import { cn } from "@/lib/utils";
+import TransactionTimeline from "./TransactionTimeline";
+import CountdownTimer from "./CountdownTimer";
+import ConfettiSuccess from "./ConfettiSuccess";
+import EventLog from "./EventLog";
+
+type ViewRole = "buyer" | "seller";
+
+export default function OrderDetails() {
+  const [transaction, setTransaction] = useState<EscrowTransaction>(mockTransaction);
+  const [viewRole, setViewRole] = useState<ViewRole>("buyer");
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const currentStateIndex = ESCROW_STATES.findIndex(
+    (s) => s.state === transaction.currentState
+  );
+
+  const handleConfirmReceipt = async () => {
+    setIsProcessing(true);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setTransaction((prev) => ({
+      ...prev,
+      currentState: "released" as EscrowState,
+      events: [
+        ...prev.events,
+        {
+          id: `ev-${prev.events.length + 1}`,
+          state: "released" as EscrowState,
+          label: "Funds Released",
+          timestamp: new Date().toISOString(),
+          actor: "buyer" as const,
+          description:
+            "Buyer confirmed receipt. Escrowed 2,500 XLM released to the seller's wallet.",
+        },
+      ],
+    }));
+    setIsProcessing(false);
+    setShowConfetti(true);
+  };
+
+  const handleOpenDispute = async () => {
+    setIsProcessing(true);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setTransaction((prev) => ({
+      ...prev,
+      currentState: "disputed" as EscrowState,
+      events: [
+        ...prev.events,
+        {
+          id: `ev-${prev.events.length + 1}`,
+          state: "disputed" as EscrowState,
+          label: "Dispute Opened",
+          timestamp: new Date().toISOString(),
+          actor: "buyer" as const,
+          description:
+            "Buyer raised a dispute. The escrow is now frozen pending arbitration.",
+        },
+      ],
+    }));
+    setIsProcessing(false);
+  };
+
+  const handleSubmitDelivery = async () => {
+    setIsProcessing(true);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setTransaction((prev) => ({
+      ...prev,
+      currentState: "in_transit" as EscrowState,
+      events: [
+        ...prev.events,
+        {
+          id: `ev-${prev.events.length + 1}`,
+          state: "in_transit" as EscrowState,
+          label: "Delivery Proof Submitted",
+          timestamp: new Date().toISOString(),
+          actor: "seller" as const,
+          description: "Seller submitted proof of delivery. Awaiting buyer confirmation.",
+        },
+      ],
+    }));
+    setIsProcessing(false);
+  };
+
+  const closeConfetti = useCallback(() => setShowConfetti(false), []);
+
+  const needsAction = () => {
+    if (transaction.currentState === "released" || transaction.currentState === "disputed")
+      return null;
+    if (transaction.currentState === "in_escrow") return "seller";
+    if (transaction.currentState === "in_transit") return "buyer";
+    return null;
+  };
+
+  const actionNeeded = needsAction();
+
+  return (
+    <div className="space-y-10">
+      <ConfettiSuccess show={showConfetti} onClose={closeConfetti} />
+
+      {/* Role Switcher */}
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-neutral-500 uppercase tracking-widest font-bold">Viewing as:</span>
+        <div className="flex bg-white/5 rounded-xl p-1 border border-white/10">
+          {(["buyer", "seller"] as ViewRole[]).map((role) => (
+            <button
+              key={role}
+              onClick={() => setViewRole(role)}
+              className={cn(
+                "px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all",
+                viewRole === role
+                  ? "bg-blue-600 text-white shadow-lg"
+                  : "text-neutral-400 hover:text-white"
+              )}
+            >
+              {role}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div className="p-8 bg-white/5 border border-white/10 rounded-3xl">
+        <TransactionTimeline currentState={transaction.currentState} />
+      </div>
+
+      {/* Status + Action Banner */}
+      {actionNeeded && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className={cn(
+            "p-6 rounded-2xl border flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4",
+            actionNeeded === viewRole
+              ? "bg-blue-500/10 border-blue-500/30"
+              : "bg-white/5 border-white/10"
+          )}
+        >
+          <div className="flex items-center gap-3">
+            {actionNeeded === viewRole ? (
+              <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center animate-pulse shrink-0">
+                <ArrowRight className="w-5 h-5 text-white" />
+              </div>
+            ) : (
+              <div className="w-10 h-10 bg-white/10 rounded-full flex items-center justify-center shrink-0">
+                <Wallet className="w-5 h-5 text-neutral-400" />
+              </div>
+            )}
+            <div>
+              <p className="text-sm font-bold text-white">
+                {actionNeeded === viewRole
+                  ? "Action Required — It's your turn"
+                  : `Waiting for the ${actionNeeded}`}
+              </p>
+              <p className="text-xs text-neutral-400 mt-0.5">
+                {actionNeeded === "buyer"
+                  ? "The buyer must confirm receipt or open a dispute."
+                  : "The seller must submit delivery proof."}
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      )}
+
+      {/* Main Content Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left: Details + Events */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Asset Details Card */}
+          <div className="p-6 bg-white/5 border border-white/10 rounded-3xl shadow-inner space-y-4">
+            <h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest border-b border-white/5 pb-2">
+              Asset Details
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <span className="text-xs text-neutral-500 uppercase block mb-1">Name</span>
+                <span className="text-lg font-bold text-white">{transaction.assetName}</span>
+              </div>
+              <div>
+                <span className="text-xs text-neutral-500 uppercase block mb-1">Category</span>
+                <span className="inline-block px-3 py-1 bg-white/10 text-white rounded-lg text-xs font-bold uppercase">
+                  {transaction.assetCategory}
+                </span>
+              </div>
+              <div>
+                <span className="text-xs text-neutral-500 uppercase block mb-1">Contract ID</span>
+                <span className="text-sm font-mono text-blue-400">{transaction.id}</span>
+              </div>
+              <div>
+                <span className="text-xs text-neutral-500 uppercase block mb-1">Escrowed Amount</span>
+                <span className="text-2xl font-black text-blue-400">
+                  {transaction.priceXLM.toLocaleString()} <span className="text-base">XLM</span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Event Log */}
+          <div className="p-6 bg-white/5 border border-white/10 rounded-3xl shadow-inner">
+            <EventLog events={transaction.events} />
+          </div>
+        </div>
+
+        {/* Right: Actions + Timer */}
+        <div className="space-y-6">
+          {/* Parties */}
+          <div className="p-6 bg-white/5 border border-white/10 rounded-3xl shadow-inner space-y-4">
+            <h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest border-b border-white/5 pb-2">
+              Parties
+            </h3>
+            <div>
+              <span className="text-xs text-neutral-500 uppercase block mb-1">Buyer</span>
+              <p className="text-sm font-bold text-white">{transaction.buyer.name}</p>
+              <p className="text-xs font-mono text-neutral-500">{transaction.buyer.address}</p>
+            </div>
+            <div>
+              <span className="text-xs text-neutral-500 uppercase block mb-1">Seller</span>
+              <p className="text-sm font-bold text-white">{transaction.seller.name}</p>
+              <p className="text-xs font-mono text-neutral-500">{transaction.seller.address}</p>
+            </div>
+          </div>
+
+          {/* Countdown Timer */}
+          {transaction.currentState !== "released" &&
+            transaction.currentState !== "disputed" && (
+              <div className="p-6 bg-white/5 border border-white/10 rounded-3xl shadow-inner">
+                <CountdownTimer
+                  targetDate={transaction.autoReleaseAt}
+                  label="Auto-release in"
+                />
+              </div>
+            )}
+
+          {/* Action Buttons */}
+          {transaction.currentState !== "released" &&
+            transaction.currentState !== "disputed" && (
+              <div className="p-6 bg-white/5 border border-white/10 rounded-3xl shadow-inner space-y-4">
+                <h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest border-b border-white/5 pb-2">
+                  Actions
+                </h3>
+
+                {viewRole === "buyer" && transaction.currentState === "in_transit" && (
+                  <div className="space-y-3">
+                    <button
+                      onClick={handleConfirmReceipt}
+                      disabled={isProcessing}
+                      className={cn(
+                        "w-full px-6 py-3 rounded-xl font-bold text-sm transition-all flex items-center justify-center gap-2 active:scale-95",
+                        isProcessing
+                          ? "bg-green-600/50 text-white/50 cursor-not-allowed"
+                          : "bg-green-600 hover:bg-green-500 text-white shadow-lg shadow-green-600/30"
+                      )}
+                    >
+                      <CheckCircle2 className="w-4 h-4" />
+                      {isProcessing ? "Processing…" : "Confirm Receipt"}
+                    </button>
+                    <button
+                      onClick={handleOpenDispute}
+                      disabled={isProcessing}
+                      className={cn(
+                        "w-full px-6 py-3 rounded-xl font-bold text-sm transition-all flex items-center justify-center gap-2 active:scale-95",
+                        isProcessing
+                          ? "bg-red-600/50 text-white/50 cursor-not-allowed"
+                          : "bg-red-600/10 hover:bg-red-600/20 text-red-400 border border-red-500/30"
+                      )}
+                    >
+                      <ShieldAlert className="w-4 h-4" />
+                      {isProcessing ? "Processing…" : "Open Dispute"}
+                    </button>
+                  </div>
+                )}
+
+                {viewRole === "seller" && transaction.currentState === "in_escrow" && (
+                  <button
+                    onClick={handleSubmitDelivery}
+                    disabled={isProcessing}
+                    className={cn(
+                      "w-full px-6 py-3 rounded-xl font-bold text-sm transition-all flex items-center justify-center gap-2 active:scale-95",
+                      isProcessing
+                        ? "bg-blue-600/50 text-white/50 cursor-not-allowed"
+                        : "bg-blue-600 hover:bg-blue-500 text-white shadow-lg shadow-blue-600/30"
+                    )}
+                  >
+                    <Send className="w-4 h-4" />
+                    {isProcessing ? "Submitting…" : "Submit Delivery Proof"}
+                  </button>
+                )}
+
+                {viewRole === "buyer" && transaction.currentState !== "in_transit" && (
+                  <p className="text-xs text-neutral-500 text-center py-2">
+                    Waiting for seller to submit delivery proof before you can act.
+                  </p>
+                )}
+                {viewRole === "seller" && transaction.currentState !== "in_escrow" && (
+                  <p className="text-xs text-neutral-500 text-center py-2">
+                    Delivery proof submitted. Awaiting buyer confirmation.
+                  </p>
+                )}
+              </div>
+            )}
+
+          {/* Completed / Disputed state */}
+          {transaction.currentState === "released" && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="p-6 bg-green-500/10 border border-green-500/20 rounded-3xl text-center space-y-2"
+            >
+              <CheckCircle2 className="w-10 h-10 text-green-400 mx-auto" />
+              <h3 className="text-lg font-black text-green-400">Transaction Complete</h3>
+              <p className="text-xs text-green-300/60">Funds have been released to the seller.</p>
+            </motion.div>
+          )}
+
+          {transaction.currentState === "disputed" && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="p-6 bg-red-500/10 border border-red-500/20 rounded-3xl text-center space-y-2"
+            >
+              <AlertTriangle className="w-10 h-10 text-red-400 mx-auto" />
+              <h3 className="text-lg font-black text-red-400">Dispute Active</h3>
+              <p className="text-xs text-red-300/60">This escrow is frozen pending arbitration.</p>
+            </motion.div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/escrow/TransactionTimeline.tsx
+++ b/src/components/escrow/TransactionTimeline.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { EscrowState, ESCROW_STATES } from "@/lib/escrowData";
+import { cn } from "@/lib/utils";
+
+interface TransactionTimelineProps {
+  currentState: EscrowState;
+}
+
+export default function TransactionTimeline({ currentState }: TransactionTimelineProps) {
+  const currentIndex = ESCROW_STATES.findIndex((s) => s.state === currentState);
+  const isDisputed = currentState === "disputed";
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between relative">
+        {/* Background track */}
+        <div className="absolute top-5 left-5 right-5 h-1 bg-white/10 rounded-full z-0" />
+        {/* Active track */}
+        <motion.div
+          className={cn(
+            "absolute top-5 left-5 h-1 rounded-full z-[1]",
+            isDisputed ? "bg-red-500" : "bg-blue-500"
+          )}
+          initial={{ width: "0%" }}
+          animate={{
+            width: `${(Math.min(currentIndex, ESCROW_STATES.length - 1) / (ESCROW_STATES.length - 1)) * 100}%`,
+          }}
+          transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1] }}
+          style={{ maxWidth: "calc(100% - 40px)" }}
+        />
+
+        {ESCROW_STATES.map((step, index) => {
+          const isCompleted = currentIndex > index;
+          const isActive = currentIndex === index;
+
+          return (
+            <div key={step.state} className="flex flex-col items-center gap-3 relative z-10">
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ delay: index * 0.15, duration: 0.5, type: "spring" }}
+                className={cn(
+                  "w-10 h-10 rounded-full flex items-center justify-center text-lg transition-all duration-500 border-2",
+                  isCompleted
+                    ? "bg-blue-600 border-blue-600 shadow-[0_0_20px_rgba(59,130,246,0.4)]"
+                    : isActive
+                    ? isDisputed
+                      ? "bg-red-600/20 border-red-500 shadow-[0_0_20px_rgba(239,68,68,0.4)]"
+                      : "bg-blue-600/20 border-blue-500 shadow-[0_0_20px_rgba(59,130,246,0.4)]"
+                    : "bg-[#111] border-white/10"
+                )}
+              >
+                {isDisputed && isActive ? "⚠️" : step.icon}
+              </motion.div>
+              <span
+                className={cn(
+                  "text-[10px] sm:text-xs font-bold uppercase tracking-widest transition-colors whitespace-nowrap",
+                  isCompleted || isActive ? "text-white" : "text-neutral-600"
+                )}
+              >
+                {isDisputed && isActive ? "Disputed" : step.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/escrowData.ts
+++ b/src/lib/escrowData.ts
@@ -1,0 +1,84 @@
+export type EscrowState = "funded" | "in_escrow" | "in_transit" | "released" | "disputed";
+
+export interface EscrowTransaction {
+  id: string;
+  assetName: string;
+  assetCategory: "Digital" | "Physical" | "Service";
+  priceXLM: number;
+  seller: {
+    name: string;
+    address: string;
+  };
+  buyer: {
+    name: string;
+    address: string;
+  };
+  currentState: EscrowState;
+  createdAt: string;
+  deliveryDeadline: string;
+  disputeDeadline: string;
+  autoReleaseAt: string;
+  events: EscrowEvent[];
+}
+
+export interface EscrowEvent {
+  id: string;
+  state: EscrowState;
+  label: string;
+  timestamp: string;
+  actor: "buyer" | "seller" | "system";
+  description: string;
+}
+
+export const ESCROW_STATES: { state: EscrowState; label: string; icon: string }[] = [
+  { state: "funded", label: "Funded", icon: "💰" },
+  { state: "in_escrow", label: "In Escrow", icon: "🔒" },
+  { state: "in_transit", label: "In Transit", icon: "📦" },
+  { state: "released", label: "Released", icon: "✅" },
+];
+
+export const mockTransaction: EscrowTransaction = {
+  id: "escrow-0x7f3a…d91e",
+  assetName: "Exclusive SaaS License — MarketBot Pro",
+  assetCategory: "Digital",
+  priceXLM: 2500,
+  seller: {
+    name: "Alice Stellaris",
+    address: "GBXY…SELLER",
+  },
+  buyer: {
+    name: "Bob Lumens",
+    address: "GCDA…BUYER",
+  },
+  currentState: "in_transit",
+  createdAt: "2026-03-20T09:00:00Z",
+  deliveryDeadline: "2026-03-27T09:00:00Z",
+  disputeDeadline: "2026-03-30T09:00:00Z",
+  autoReleaseAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  events: [
+    {
+      id: "ev-1",
+      state: "funded",
+      label: "Escrow Funded",
+      timestamp: "2026-03-20T09:00:00Z",
+      actor: "buyer",
+      description: "Buyer deposited 2,500 XLM into the Soroban escrow contract.",
+    },
+    {
+      id: "ev-2",
+      state: "in_escrow",
+      label: "Funds Locked",
+      timestamp: "2026-03-20T09:01:12Z",
+      actor: "system",
+      description: "Smart contract confirmed receipt. Funds are now locked.",
+    },
+    {
+      id: "ev-3",
+      state: "in_transit",
+      label: "Delivery Proof Submitted",
+      timestamp: "2026-03-22T14:30:00Z",
+      actor: "seller",
+      description: "Seller submitted delivery proof: License key sent via encrypted channel.",
+    },
+  ],
+};


### PR DESCRIPTION
## Description
This PR implements a high-fidelity **"Order Details" view** that visualizes the state of an escrowed transaction on the Stellar/Soroban network. It provides full transparency into the escrow lifecycle: **Funded → In Escrow → In Transit → Released/Disputed**.

## Key Features & Changes
- **[TransactionTimeline](cci:1://file:///Users/ricky/Documents/MarketX/MarketX-frontend/src/components/escrow/TransactionTimeline.tsx:10:0-70:1)**: An animated Framer Motion progress bar that maps contract states to visual steps with glowing active indicators.
- **Role-Switching UI**: A "Viewing as: Buyer / Seller" toggle so users can preview both perspectives of the transaction.
- **State-Specific Actions**:
  - **Buyer View**: "Confirm Receipt" (triggers fund release + confetti) and "Open Dispute" (freezes escrow).
  - **Seller View**: "Submit Delivery Proof" (advances state to In Transit).
- **"Who Needs to Act Next" Banner**: A dynamic indicator showing which party is expected to take the next action.
- **Real-Time Countdown Timer**: A live auto-release countdown (days/hours/mins/secs) showing when funds will be automatically released if the buyer doesn't act.
- **Confetti Celebration**: A 80-piece physics-based confetti animation fires when the buyer confirms receipt.
- **Transaction Event Log**: An animated timeline of all events (funding, locking, delivery proof, release/dispute).
- **Disputed State Handling**: Full UI support for the "Disputed" state with red indicators and frozen escrow messaging.

## How to Test
1. Pull `feat/escrow-tracker` and run `pnpm install && pnpm dev`.
2. Navigate to `/dashboard/orders`.
3. Toggle between **Buyer** and **Seller** views using the role switcher.
4. As **Buyer**, click "Confirm Receipt" to see the confetti animation and state transition to "Released".
5. Refresh, then try "Open Dispute" to see the disputed state handling.
6. Switch to **Seller** view — note the "Submit Delivery Proof" button is context-aware (only shows when state is "In Escrow").
closes #6 