### PR TITLE
refactor(ui): replace inline styles with CSS Modules for StreamCard

### DIFF
--- a/src/components/inlineCSS/StreamCard.module.css
+++ b/src/components/inlineCSS/StreamCard.module.css
@@ -1,0 +1,27 @@
+/* StreamCard.module.css */
+
+.card {
+  padding: 16px;
+  border-radius: 8px;
+  background-color: #111;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.title {
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.sender {
+  font-size: 14px;
+  color: #aaa;
+}

--- a/src/components/inlineCSS/StreamCard.tsx
+++ b/src/components/inlineCSS/StreamCard.tsx
@@ -1,0 +1,17 @@
+// components/StreamCard/StreamCard.tsx
+
+import styles from "./StreamCard.module.css";
+
+type Props = {
+  title: string;
+  sender: string;
+};
+
+export default function StreamCard({ title, sender }: Props) {
+  return (
+    <div className={styles.card}>
+      <h3 className={styles.title}>{title}</h3>
+      <p className={styles.sender}>{sender}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
refactor(ui): replace inline styles with CSS Modules for StreamCard

- Removed inline style objects from StreamCard component
- Introduced scoped CSS Module for styling
- Improved maintainability and readability
- Added hover state for better UX
- Prepared component for reuse and scalability
closes #17 