### PR TITLE
feat: add product detail page (/product/[id])

### DIFF
--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { use } from "react";
+import {
+  Star,
+  Shield,
+  ChevronLeft,
+  Heart,
+  Share2,
+  ShoppingCart,
+  CheckCircle,
+  Zap,
+  Store,
+  Package,
+} from "lucide-react";
+import { mockProducts, ProductMock } from "@/lib/mockData";
+
+export default function ProductDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const product = mockProducts.find((p) => p.id === id);
+
+  if (!product) notFound();
+
+  const images = product!.images ?? [];
+  const hasImages = images.length > 0;
+
+  return <ProductDetailView product={product!} images={images} hasImages={hasImages} />;
+}
+
+function ProductDetailView({
+  product,
+  images,
+  hasImages,
+}: {
+  product: ProductMock;
+  images: string[];
+  hasImages: boolean;
+}) {
+  const [activeImg, setActiveImg] = useState(0);
+  const [wishlisted, setWishlisted] = useState(false);
+
+  const discountSaving = product.originalUsdPrice - product.usdPrice;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 pt-20 pb-12">
+
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-1.5 text-xs text-gray-400 mb-6">
+          <Link href="/" className="hover:text-emerald-600 transition-colors">Home</Link>
+          <span>/</span>
+          <span className="hover:text-emerald-600 transition-colors cursor-pointer">{product.category}</span>
+          <span>/</span>
+          <span className="text-gray-600 truncate max-w-[200px]">{product.name}</span>
+        </nav>
+
+        {/* Back button */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-xs font-semibold text-gray-500 hover:text-emerald-600 transition-colors mb-6"
+        >
+          <ChevronLeft className="w-3.5 h-3.5" />
+          Back to listings
+        </Link>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* ── Left: Image Gallery ── */}
+          <div className="space-y-3">
+            {/* Main image */}
+            <div className="relative bg-white border border-gray-200 rounded-2xl overflow-hidden aspect-square flex items-center justify-center">
+              {hasImages ? (
+                <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                  <Package className="w-24 h-24 text-gray-300" />
+                </div>
+              ) : (
+                <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                  <Package className="w-24 h-24 text-gray-300" />
+                </div>
+              )}
+
+              {/* Badge overlay */}
+              <div className="absolute top-3 left-3 flex flex-col gap-1.5">
+                {product.discountPercent > 0 && (
+                  <span className="bg-emerald-600 text-white text-[11px] font-bold px-2 py-0.5 rounded-md">
+                    -{product.discountPercent}%
+                  </span>
+                )}
+                {product.badge === "flash" && (
+                  <span className="bg-orange-500 text-white text-[11px] font-bold px-2 py-0.5 rounded-md flex items-center gap-0.5">
+                    <Zap className="w-3 h-3" /> Flash
+                  </span>
+                )}
+                {product.badge === "hot" && (
+                  <span className="bg-red-500 text-white text-[11px] font-bold px-2 py-0.5 rounded-md">
+                    🔥 Hot
+                  </span>
+                )}
+                {product.badge === "new" && (
+                  <span className="bg-blue-500 text-white text-[11px] font-bold px-2 py-0.5 rounded-md">
+                    New
+                  </span>
+                )}
+              </div>
+
+              {/* Wishlist & Share */}
+              <div className="absolute top-3 right-3 flex flex-col gap-2">
+                <button
+                  onClick={() => setWishlisted((v: boolean) => !v)}
+                  className="w-8 h-8 rounded-full bg-white shadow-sm border border-gray-200 flex items-center justify-center hover:border-red-300 transition-colors"
+                  aria-label="Add to wishlist"
+                >
+                  <Heart
+                    className={`w-4 h-4 ${wishlisted ? "fill-red-500 text-red-500" : "text-gray-400"}`}
+                  />
+                </button>
+                <button
+                  className="w-8 h-8 rounded-full bg-white shadow-sm border border-gray-200 flex items-center justify-center hover:border-emerald-300 transition-colors"
+                  aria-label="Share product"
+                >
+                  <Share2 className="w-4 h-4 text-gray-400" />
+                </button>
+              </div>
+
+              {/* Image counter pill */}
+              {images.length > 1 && (
+                <div className="absolute bottom-3 right-3 bg-black/50 text-white text-[10px] font-semibold px-2 py-0.5 rounded-full">
+                  {activeImg + 1} / {images.length}
+                </div>
+              )}
+            </div>
+
+            {/* Thumbnails */}
+            {images.length > 1 && (
+              <div className="flex gap-2">
+                {images.map((_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setActiveImg(i)}
+                    className={`w-16 h-16 rounded-lg border-2 bg-gray-100 flex items-center justify-center transition-colors ${
+                      activeImg === i
+                        ? "border-emerald-500"
+                        : "border-gray-200 hover:border-gray-300"
+                    }`}
+                  >
+                    <Package className="w-6 h-6 text-gray-300" />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* ── Right: Product Info ── */}
+          <div className="flex flex-col gap-5">
+            {/* Category chip */}
+            <span className="inline-flex w-fit text-[11px] font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 px-2.5 py-0.5 rounded-full">
+              {product.category}
+            </span>
+
+            {/* Name */}
+            <h1 className="text-xl font-black text-gray-900 leading-snug">
+              {product.name}
+            </h1>
+
+            {/* Rating row */}
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-0.5">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <Star
+                    key={star}
+                    className={`w-3.5 h-3.5 ${
+                      star <= Math.round(product.rating)
+                        ? "fill-amber-400 text-amber-400"
+                        : "text-gray-200 fill-gray-200"
+                    }`}
+                  />
+                ))}
+              </div>
+              <span className="text-sm font-bold text-gray-700">{product.rating}</span>
+              <span className="text-xs text-gray-400">({product.reviewCount} reviews)</span>
+            </div>
+
+            {/* Pricing */}
+            <div className="bg-white border border-gray-200 rounded-xl p-4 space-y-2">
+              <div className="flex items-baseline gap-2.5">
+                <span className="text-3xl font-black text-emerald-600">
+                  ${product.usdPrice.toLocaleString()}
+                </span>
+                {product.originalUsdPrice > product.usdPrice && (
+                  <span className="text-base text-gray-400 line-through">
+                    ${product.originalUsdPrice.toLocaleString()}
+                  </span>
+                )}
+                {discountSaving > 0 && (
+                  <span className="text-xs font-bold text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">
+                    Save ${discountSaving}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-black text-gray-700">
+                  {product.xlmPrice.toLocaleString()} XLM
+                </span>
+                <span className="text-xs text-gray-400">≈ ${product.usdPrice}</span>
+                <span className="text-[10px] text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded font-medium">
+                  Stellar Network
+                </span>
+              </div>
+            </div>
+
+            {/* Escrow trust strip */}
+            <div className="flex items-start gap-2.5 bg-emerald-50 border border-emerald-200 rounded-xl p-3.5">
+              <Shield className="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-bold text-emerald-800">Protected by Stellar Escrow</p>
+                <p className="text-[11px] text-emerald-700 leading-relaxed mt-0.5">
+                  Funds are held in a smart contract until you confirm delivery. Safe, transparent, and trustless.
+                </p>
+              </div>
+            </div>
+
+            {/* CTA buttons */}
+            <div className="flex flex-col gap-2.5">
+              <button className="w-full py-3.5 bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800 text-white font-black text-sm rounded-xl flex items-center justify-center gap-2 transition-colors shadow-sm">
+                <Shield className="w-4 h-4" />
+                Buy with Escrow
+              </button>
+              <button className="w-full py-3 border border-gray-200 hover:border-emerald-400 hover:bg-emerald-50 text-gray-700 font-semibold text-sm rounded-xl flex items-center justify-center gap-2 transition-colors">
+                <ShoppingCart className="w-4 h-4" />
+                Add to Cart
+              </button>
+            </div>
+
+            {/* Delivery / guarantee chips */}
+            <div className="flex flex-wrap gap-2">
+              {[
+                { icon: <CheckCircle className="w-3.5 h-3.5 text-emerald-600" />, label: "Buyer Protection" },
+                { icon: <Package className="w-3.5 h-3.5 text-emerald-600" />, label: "Fast Shipping" },
+                { icon: <Shield className="w-3.5 h-3.5 text-emerald-600" />, label: "Secure Payment" },
+              ].map(({ icon, label }) => (
+                <div
+                  key={label}
+                  className="flex items-center gap-1 text-[11px] font-semibold text-gray-600 bg-white border border-gray-200 px-2.5 py-1 rounded-full"
+                >
+                  {icon}
+                  {label}
+                </div>
+              ))}
+            </div>
+
+            {/* Description */}
+            {product.description && (
+              <div className="space-y-2">
+                <h2 className="text-sm font-black text-gray-900">About this item</h2>
+                <p className="text-sm text-gray-600 leading-relaxed">{product.description}</p>
+              </div>
+            )}
+
+            {/* Seller card */}
+            <div className="bg-white border border-gray-200 rounded-xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-black text-gray-900">Seller</h2>
+                <Link
+                  href="#"
+                  className="text-xs font-semibold text-emerald-600 hover:text-emerald-700"
+                >
+                  View store →
+                </Link>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-emerald-600 flex items-center justify-center text-white text-sm font-black shrink-0">
+                  {product.seller.charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <p className="text-sm font-bold text-gray-900 truncate">{product.seller}</p>
+                    <CheckCircle className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
+                  </div>
+                  <div className="flex items-center gap-3 mt-0.5">
+                    <div className="flex items-center gap-0.5">
+                      <Star className="w-3 h-3 fill-amber-400 text-amber-400" />
+                      <span className="text-[11px] font-semibold text-gray-600">
+                        {product.sellerRating ?? "N/A"}
+                      </span>
+                    </div>
+                    {product.sellerSales != null && (
+                      <div className="flex items-center gap-1">
+                        <Store className="w-3 h-3 text-gray-400" />
+                        <span className="text-[11px] text-gray-400">
+                          {product.sellerSales.toLocaleString()} sales
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <button className="shrink-0 text-[11px] font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 px-3 py-1.5 rounded-lg hover:bg-emerald-600 hover:text-white hover:border-emerald-600 transition-colors">
+                  Contact
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Related products strip ── */}
+        <RelatedProducts currentId={product.id} category={product.category} />
+      </div>
+    </div>
+  );
+}
+
+function RelatedProducts({
+  currentId,
+  category,
+}: {
+  currentId: string;
+  category: string;
+}) {
+  const related = mockProducts
+    .filter((p) => p.id !== currentId && p.category === category)
+    .slice(0, 4);
+
+  if (related.length === 0) return null;
+
+  return (
+    <section className="mt-12">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-black text-gray-900">More in {category}</h2>
+        <Link href="/" className="text-xs font-semibold text-emerald-600 hover:text-emerald-700">
+          View all →
+        </Link>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+        {related.map((p) => (
+          <Link
+            key={p.id}
+            href={`/product/${p.id}`}
+            className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-md transition-shadow group"
+          >
+            <div className="relative h-32 bg-gray-100 flex items-center justify-center">
+              <Package className="w-12 h-12 text-gray-300" />
+              {p.discountPercent > 0 && (
+                <span className="absolute top-2 left-2 bg-emerald-600 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+                  -{p.discountPercent}%
+                </span>
+              )}
+            </div>
+            <div className="p-3">
+              <p className="text-xs text-gray-700 font-semibold line-clamp-2 min-h-[2.5rem] leading-snug mb-1">
+                {p.name}
+              </p>
+              <span className="text-sm font-black text-emerald-600">${p.usdPrice}</span>
+              <p className="text-[10px] text-gray-400 font-semibold">
+                ≈ {p.xlmPrice.toLocaleString()} XLM
+              </p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/marketplace/ProductCard.tsx
+++ b/src/components/marketplace/ProductCard.tsx
@@ -1,9 +1,10 @@
+import Link from "next/link";
 import { Star } from "lucide-react";
 import { ProductMock } from "@/lib/mockData";
 
 export default function ProductCard({ product }: { product: ProductMock }) {
   return (
-    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow group">
+    <Link href={`/product/${product.id}`} className="bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow group block">
       {/* Image placeholder */}
       <div className="relative h-36 bg-gray-100 flex items-center justify-center">
         <div className="w-16 h-16 bg-gray-200 rounded-lg" />
@@ -55,6 +56,6 @@ export default function ProductCard({ product }: { product: ProductMock }) {
           + Add to Cart
         </button>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -149,17 +149,71 @@ export interface ProductMock {
   category: string;
   seller: string;
   badge?: "flash" | "new" | "hot";
+  description?: string;
+  images?: string[];
+  sellerRating?: number;
+  sellerSales?: number;
 }
 
 export const mockProducts: ProductMock[] = [
-  { id: "p1", name: "Samsung Galaxy A55 5G", usdPrice: 299, originalUsdPrice: 459, xlmPrice: 1450, discountPercent: 35, rating: 4.5, reviewCount: 312, category: "Electronics", seller: "TechHub NG", badge: "flash" },
-  { id: "p2", name: "Nike Air Max 270", usdPrice: 88, originalUsdPrice: 110, xlmPrice: 427, discountPercent: 20, rating: 4.7, reviewCount: 198, category: "Fashion", seller: "SoleKing", badge: "hot" },
-  { id: "p3", name: "Sony WH-1000XM5", usdPrice: 193, originalUsdPrice: 350, xlmPrice: 936, discountPercent: 45, rating: 4.8, reviewCount: 540, category: "Electronics", seller: "AudioWorld", badge: "flash" },
-  { id: "p4", name: "Levi's 501 Original Jeans", usdPrice: 45, originalUsdPrice: 60, xlmPrice: 218, discountPercent: 25, rating: 4.3, reviewCount: 87, category: "Fashion", seller: "DenimCo" },
-  { id: "p5", name: "Anker 65W GaN Charger", usdPrice: 28, originalUsdPrice: 40, xlmPrice: 136, discountPercent: 30, rating: 4.6, reviewCount: 231, category: "Electronics", seller: "PowerDeals" },
-  { id: "p6", name: "JBL Flip 6 Speaker", usdPrice: 99, originalUsdPrice: 130, xlmPrice: 480, discountPercent: 24, rating: 4.4, reviewCount: 175, category: "Electronics", seller: "SoundZone", badge: "new" },
-  { id: "p7", name: "Adidas Ultraboost 22", usdPrice: 120, originalUsdPrice: 180, xlmPrice: 582, discountPercent: 33, rating: 4.6, reviewCount: 94, category: "Fashion", seller: "SoleKing" },
-  { id: "p8", name: "Xiaomi Smart Band 9", usdPrice: 35, originalUsdPrice: 50, xlmPrice: 170, discountPercent: 30, rating: 4.2, reviewCount: 412, category: "Electronics", seller: "TechHub NG" },
-  { id: "p9", name: "Legendary NFT #0042", usdPrice: 450, originalUsdPrice: 450, xlmPrice: 2183, discountPercent: 0, rating: 5.0, reviewCount: 12, category: "NFTs", seller: "art_node", badge: "hot" },
-  { id: "p10", name: "iPhone 15 Case (MagSafe)", usdPrice: 19, originalUsdPrice: 25, xlmPrice: 92, discountPercent: 24, rating: 4.1, reviewCount: 63, category: "Electronics", seller: "CaseWorld" },
+  {
+    id: "p1", name: "Samsung Galaxy A55 5G", usdPrice: 299, originalUsdPrice: 459, xlmPrice: 1450, discountPercent: 35, rating: 4.5, reviewCount: 312, category: "Electronics", seller: "TechHub NG", badge: "flash",
+    sellerRating: 4.8, sellerSales: 1240,
+    description: "The Samsung Galaxy A55 5G delivers flagship-level performance at a mid-range price. Featuring a 6.6\" Super AMOLED display, 50MP OIS camera, 5000mAh battery, and 5G connectivity. Comes with 8GB RAM and 256GB internal storage.",
+    images: ["/products/p1-1.jpg", "/products/p1-2.jpg", "/products/p1-3.jpg"],
+  },
+  {
+    id: "p2", name: "Nike Air Max 270", usdPrice: 88, originalUsdPrice: 110, xlmPrice: 427, discountPercent: 20, rating: 4.7, reviewCount: 198, category: "Fashion", seller: "SoleKing", badge: "hot",
+    sellerRating: 4.9, sellerSales: 3200,
+    description: "The Nike Air Max 270 features Nike's biggest heel Air unit yet for an incredibly plush feel with every step. The mesh upper provides lightweight breathability, while the updated rubber outsole gives you durable traction on any surface.",
+    images: ["/products/p2-1.jpg", "/products/p2-2.jpg", "/products/p2-3.jpg"],
+  },
+  {
+    id: "p3", name: "Sony WH-1000XM5", usdPrice: 193, originalUsdPrice: 350, xlmPrice: 936, discountPercent: 45, rating: 4.8, reviewCount: 540, category: "Electronics", seller: "AudioWorld", badge: "flash",
+    sellerRating: 4.7, sellerSales: 890,
+    description: "Industry-leading noise cancellation with eight microphones and two processors. 30-hour battery life, multipoint connection for two devices simultaneously. Ultra-comfortable over-ear design with soft fit leather earpads.",
+    images: ["/products/p3-1.jpg", "/products/p3-2.jpg", "/products/p3-3.jpg"],
+  },
+  {
+    id: "p4", name: "Levi's 501 Original Jeans", usdPrice: 45, originalUsdPrice: 60, xlmPrice: 218, discountPercent: 25, rating: 4.3, reviewCount: 87, category: "Fashion", seller: "DenimCo",
+    sellerRating: 4.5, sellerSales: 620,
+    description: "The original jean since 1873. Levi's 501 is a straight fit with a button fly, sits at the waist, and is made from 100% cotton denim. A timeless piece that gets better with every wear.",
+    images: ["/products/p4-1.jpg", "/products/p4-2.jpg"],
+  },
+  {
+    id: "p5", name: "Anker 65W GaN Charger", usdPrice: 28, originalUsdPrice: 40, xlmPrice: 136, discountPercent: 30, rating: 4.6, reviewCount: 231, category: "Electronics", seller: "PowerDeals",
+    sellerRating: 4.6, sellerSales: 4100,
+    description: "Charge your laptop, phone, and tablet simultaneously with Anker's compact 65W GaN charger. 3 ports (2× USB-C + 1× USB-A), foldable prongs, and ActiveShield 2.0 technology that monitors temperature 3 million times per day.",
+    images: ["/products/p5-1.jpg", "/products/p5-2.jpg"],
+  },
+  {
+    id: "p6", name: "JBL Flip 6 Speaker", usdPrice: 99, originalUsdPrice: 130, xlmPrice: 480, discountPercent: 24, rating: 4.4, reviewCount: 175, category: "Electronics", seller: "SoundZone", badge: "new",
+    sellerRating: 4.4, sellerSales: 730,
+    description: "Bold sound wherever you go. JBL Flip 6 delivers powerful JBL Original Pro Sound with a racetrack-shaped driver and separate tweeter. IP67 waterproof and dustproof, with 12 hours of playtime and JBL PartyBoost.",
+    images: ["/products/p6-1.jpg", "/products/p6-2.jpg", "/products/p6-3.jpg"],
+  },
+  {
+    id: "p7", name: "Adidas Ultraboost 22", usdPrice: 120, originalUsdPrice: 180, xlmPrice: 582, discountPercent: 33, rating: 4.6, reviewCount: 94, category: "Fashion", seller: "SoleKing",
+    sellerRating: 4.9, sellerSales: 3200,
+    description: "Engineered for long-distance running. The Adidas Ultraboost 22 features a responsive Boost midsole with a Linear Energy Push system for forward propulsion. Primeknit upper wraps your foot for a sock-like fit.",
+    images: ["/products/p7-1.jpg", "/products/p7-2.jpg"],
+  },
+  {
+    id: "p8", name: "Xiaomi Smart Band 9", usdPrice: 35, originalUsdPrice: 50, xlmPrice: 170, discountPercent: 30, rating: 4.2, reviewCount: 412, category: "Electronics", seller: "TechHub NG",
+    sellerRating: 4.8, sellerSales: 1240,
+    description: "Track your health around the clock with the Xiaomi Smart Band 9. 1.62\" AMOLED display, 14-day battery life, 150+ workout modes, blood oxygen monitoring, sleep tracking, and 5ATM water resistance.",
+    images: ["/products/p8-1.jpg", "/products/p8-2.jpg"],
+  },
+  {
+    id: "p9", name: "Legendary NFT #0042", usdPrice: 450, originalUsdPrice: 450, xlmPrice: 2183, discountPercent: 0, rating: 5.0, reviewCount: 12, category: "NFTs", seller: "art_node", badge: "hot",
+    sellerRating: 4.9, sellerSales: 58,
+    description: "A one-of-a-kind generative art piece from the Legendary collection. This NFT grants exclusive membership to the Legendary DAO, access to future drops, and commercial usage rights. Minted on Stellar and secured by smart contract escrow.",
+    images: ["/products/p9-1.jpg", "/products/p9-2.jpg", "/products/p9-3.jpg"],
+  },
+  {
+    id: "p10", name: "iPhone 15 Case (MagSafe)", usdPrice: 19, originalUsdPrice: 25, xlmPrice: 92, discountPercent: 24, rating: 4.1, reviewCount: 63, category: "Electronics", seller: "CaseWorld",
+    sellerRating: 4.3, sellerSales: 980,
+    description: "Premium MagSafe-compatible case for iPhone 15. Military-grade drop protection with a slim profile, precise cutouts, and built-in magnets that snap perfectly to all MagSafe accessories. Available in multiple colors.",
+    images: ["/products/p10-1.jpg", "/products/p10-2.jpg"],
+  },
 ];


### PR DESCRIPTION
# feat: Product Detail Page (`/product/[id]`)

## Summary

Implements the full product detail page at route `/product/[id]`, resolving the missing page that `ProductCard` links were pointing to. Also enriches the mock data layer and connects the card grid to the detail route.

---

## Changes

### `src/app/product/[id]/page.tsx` *(new)*

Full product detail view built as a `"use client"` page. Sections include:

- **Image Gallery** — main image area with badge overlays (Flash / Hot / New / discount %), thumbnail strip for multi-image products, image counter pill, and wishlist / share action buttons
- **Pricing Block** — USD price (large), original USD strikethrough, savings badge, and XLM equivalent with Stellar Network label
- **Escrow Trust Strip** — shield icon callout explaining Stellar smart contract escrow protection
- **CTAs** — primary **"Buy with Escrow"** button and secondary **"Add to Cart"** button
- **Guarantee Chips** — Buyer Protection, Fast Shipping, Secure Payment
- **Description** — rendered when `product.description` is present
- **Seller Card** — avatar initial, verified checkmark, seller name, star rating, total sales count, and a Contact button
- **Related Products** — horizontal grid of up to 4 same-category products (excludes current), each linking to their own detail page
- **Breadcrumb + Back link** — Home → Category → Product Name, plus a back-to-listings chevron link
- **404 handling** — calls `notFound()` for any unrecognised product ID

---

### `src/lib/mockData.ts`

Extended `ProductMock` interface with four new optional fields:

```ts
description?: string;
images?: string[];
sellerRating?: number;
sellerSales?: number;
```

All 10 mock products (`p1`–`p10`) enriched with realistic descriptions, image path arrays, seller ratings, and sales counts.

---

### `src/components/marketplace/ProductCard.tsx`

Wrapped the card root element in a `<Link href={`/product/${product.id}`}>` so every card on the homepage, flash sale section, and wishlist page navigates to the detail page on click.

---

## Screenshots

> _Attach screenshots of the product detail page (desktop + mobile) before merging._

---

## Testing Checklist

- [ ] Navigate to `/product/p1` — full page renders correctly
- [ ] Navigate to `/product/invalid` — returns 404
- [ ] Clicking any `ProductCard` on the homepage routes to the correct detail page
- [ ] XLM and USD prices display correctly for all 10 products
- [ ] Discount badge and savings label appear only when `discountPercent > 0`
- [ ] Flash / Hot / New badges render per product
- [ ] Wishlist heart toggles fill state on click
- [ ] Related products strip shows only same-category items, excludes current product
- [ ] Seller card displays `sellerRating` and `sellerSales` where available
- [ ] Responsive layout on mobile (stacked) and desktop (two-column grid)

---

## Related

 Closes #59
- Branch: `feat/product-detail-page`
