### PR TITLE
fix: highlight active category bar pill

### DIFF
--- a/src/components/home/CategoryChips.tsx
+++ b/src/components/home/CategoryChips.tsx
@@ -19,7 +19,7 @@ export default function CategoryChips() {
         {CHIPS.map((chip) => (
           <Link
             key={chip.value || "more"}
-            href={chip.value ? `/?cat=${chip.value}` : "/"}
+            href={chip.value ? `/?category=${chip.value}` : "/"}
             className="flex flex-col items-center gap-1.5 p-3 bg-white border border-gray-200 rounded-xl hover:border-emerald-400 hover:bg-emerald-50 transition-colors group"
           >
             <span className="text-2xl">{chip.emoji}</span>

--- a/src/components/home/HeroBanners.tsx
+++ b/src/components/home/HeroBanners.tsx
@@ -28,7 +28,7 @@ export default function HeroBanners() {
       {/* Side banners (1/3 width, stacked) */}
       <div className="flex-1 flex flex-col gap-3">
         <Link
-          href="/?cat=Electronics"
+          href="/?category=Electronics"
           className="flex-1 bg-gradient-to-br from-emerald-50 to-teal-50 border border-emerald-100 rounded-xl p-4 hover:border-emerald-300 transition-colors group"
         >
           <div className="text-lg mb-1">📱</div>
@@ -36,7 +36,7 @@ export default function HeroBanners() {
           <p className="text-[11px] text-gray-500 mt-0.5">Up to 30% off</p>
         </Link>
         <Link
-          href="/?cat=Fashion"
+          href="/?category=Fashion"
           className="flex-1 bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-100 rounded-xl p-4 hover:border-blue-300 transition-colors group"
         >
           <div className="text-lg mb-1">🌟</div>

--- a/src/components/layout/CategoryBar.tsx
+++ b/src/components/layout/CategoryBar.tsx
@@ -17,7 +17,7 @@ const CATEGORIES = [
 export default function CategoryBar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const currentCat = searchParams.get("cat") ?? "";
+  const currentCategory = searchParams.get("category") ?? searchParams.get("cat") ?? "";
 
   if (
     pathname.startsWith("/auth") ||
@@ -43,9 +43,9 @@ export default function CategoryBar() {
         {CATEGORIES.map((cat) => (
           <Link
             key={cat.value || "all"}
-            href={cat.value ? `/?cat=${cat.value}` : "/"}
+            href={cat.value ? `/?category=${cat.value}` : "/"}
             className={`px-3 py-1 text-xs font-semibold whitespace-nowrap transition-colors rounded-sm ${
-              currentCat === cat.value && pathname !== "/marketplace"
+              currentCategory === cat.value && pathname !== "/marketplace"
                 ? "text-white font-bold bg-black/20"
                 : "text-emerald-100 hover:text-white hover:bg-black/10"
             }`}


### PR DESCRIPTION
## Summary
- highlight the emerald CategoryBar pill using the `?category=` search param
- update category entry points to emit `?category=` links
- keep backward compatibility with the legacy `?cat=` param for existing URLs

Closes #67

## Validation
- `npx eslint src/components/layout/CategoryBar.tsx src/components/home/CategoryChips.tsx src/components/home/HeroBanners.tsx`
- `npm run build`
- `git diff --check`

Note: full `npm run lint` still reports pre-existing repo lint errors in `Navbar.tsx` and `ThemeToggle.tsx` (`react-hooks/set-state-in-effect`) plus unrelated warnings; the changed files pass scoped eslint and the production build passes.