### PR TITLE
fix: link form error messages to fields

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -114,10 +114,11 @@ function LoginForm() {
                 onBlur={() => setTouched((p) => ({ ...p, email: true }))}
                 placeholder="name@example.com"
                 className={fieldClass("email", touched.email)}
-                aria-invalid={!!errors.email}
+                aria-invalid={!!errors.email && touched.email}
+                aria-describedby={errors.email && touched.email ? "login-email-error" : undefined}
               />
               {errors.email && touched.email && (
-                <p className="text-xs text-red-600 mt-1" role="alert">{errors.email}</p>
+                <p id="login-email-error" className="text-xs text-red-600 mt-1" role="alert">{errors.email}</p>
               )}
             </div>
 
@@ -138,10 +139,11 @@ function LoginForm() {
                 onBlur={() => setTouched((p) => ({ ...p, password: true }))}
                 placeholder="••••••••"
                 className={fieldClass("password", touched.password)}
-                aria-invalid={!!errors.password}
+                aria-invalid={!!errors.password && touched.password}
+                aria-describedby={errors.password && touched.password ? "login-password-error" : undefined}
               />
               {errors.password && touched.password && (
-                <p className="text-xs text-red-600 mt-1" role="alert">{errors.password}</p>
+                <p id="login-password-error" className="text-xs text-red-600 mt-1" role="alert">{errors.password}</p>
               )}
             </div>
 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -152,9 +152,11 @@ export default function RegisterPage() {
                   onBlur={() => setTouched((p) => ({ ...p, firstName: true }))}
                   placeholder="John"
                   className={fieldClass("firstName", touched.firstName)}
+                  aria-invalid={!!errors.firstName && touched.firstName}
+                  aria-describedby={errors.firstName && touched.firstName ? "register-first-name-error" : undefined}
                 />
                 {errors.firstName && touched.firstName && (
-                  <p className="text-xs text-red-600 mt-1" role="alert">
+                  <p id="register-first-name-error" className="text-xs text-red-600 mt-1" role="alert">
                     {errors.firstName}
                   </p>
                 )}
@@ -171,9 +173,11 @@ export default function RegisterPage() {
                   onBlur={() => setTouched((p) => ({ ...p, lastName: true }))}
                   placeholder="Doe"
                   className={fieldClass("lastName", touched.lastName)}
+                  aria-invalid={!!errors.lastName && touched.lastName}
+                  aria-describedby={errors.lastName && touched.lastName ? "register-last-name-error" : undefined}
                 />
                 {errors.lastName && touched.lastName && (
-                  <p className="text-xs text-red-600 mt-1" role="alert">
+                  <p id="register-last-name-error" className="text-xs text-red-600 mt-1" role="alert">
                     {errors.lastName}
                   </p>
                 )}
@@ -192,9 +196,11 @@ export default function RegisterPage() {
                 onBlur={() => setTouched((p) => ({ ...p, email: true }))}
                 placeholder="name@example.com"
                 className={fieldClass("email", touched.email)}
+                aria-invalid={!!errors.email && touched.email}
+                aria-describedby={errors.email && touched.email ? "register-email-error" : undefined}
               />
               {errors.email && touched.email && (
-                <p className="text-xs text-red-600 mt-1" role="alert">
+                <p id="register-email-error" className="text-xs text-red-600 mt-1" role="alert">
                   {errors.email}
                 </p>
               )}
@@ -212,9 +218,11 @@ export default function RegisterPage() {
                 onBlur={() => setTouched((p) => ({ ...p, password: true }))}
                 placeholder="Minimum 8 characters"
                 className={fieldClass("password", touched.password)}
+                aria-invalid={!!errors.password && touched.password}
+                aria-describedby={errors.password && touched.password ? "register-password-error" : undefined}
               />
               {errors.password && touched.password && (
-                <p className="text-xs text-red-600 mt-1" role="alert">
+                <p id="register-password-error" className="text-xs text-red-600 mt-1" role="alert">
                   {errors.password}
                 </p>
               )}

--- a/src/components/selling/Step2Pricing.tsx
+++ b/src/components/selling/Step2Pricing.tsx
@@ -28,7 +28,7 @@ export default function Step2Pricing() {
               type="number"
               step="0.01"
               aria-invalid={!!errors.priceAmount}
-              aria-describedby={errors.priceAmount ? "price-error" : undefined}
+              aria-describedby={errors.priceAmount ? "price-error price-hint" : "price-hint"}
               {...register("priceAmount", { valueAsNumber: true })}
               placeholder="0.00"
               className={cn(
@@ -45,7 +45,7 @@ export default function Step2Pricing() {
               <span className="text-lg font-bold text-gray-400">XLM</span>
             </div>
           </div>
-          <p className="text-xs text-gray-400">Enter the price in XLM. Funds are held in escrow until both parties confirm.</p>
+          <p id="price-hint" className="text-xs text-gray-400">Enter the price in XLM. Funds are held in escrow until both parties confirm.</p>
           {errors.priceAmount && <p id="price-error" className="text-xs text-red-500 font-medium" role="alert">{errors.priceAmount.message}</p>}
         </div>
 
@@ -60,7 +60,7 @@ export default function Step2Pricing() {
                 id="delivery-timeframe"
                 type="number"
                 aria-invalid={!!errors.deliveryTimeframe}
-                aria-describedby={errors.deliveryTimeframe ? "delivery-error" : undefined}
+                aria-describedby={errors.deliveryTimeframe ? "delivery-error delivery-hint" : "delivery-hint"}
                 {...register("deliveryTimeframe", { valueAsNumber: true })}
                 placeholder="e.g. 7"
                 className={cn(
@@ -74,7 +74,7 @@ export default function Step2Pricing() {
               />
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-gray-400">Days</span>
             </div>
-            <p className="text-xs text-gray-400 mt-1">Time allowed to deliver the asset after escrow funding.</p>
+            <p id="delivery-hint" className="text-xs text-gray-400 mt-1">Time allowed to deliver the asset after escrow funding.</p>
             {errors.deliveryTimeframe && <p id="delivery-error" className="text-xs text-red-500 font-medium" role="alert">{errors.deliveryTimeframe.message}</p>}
           </div>
 
@@ -86,7 +86,7 @@ export default function Step2Pricing() {
                 id="dispute-period"
                 type="number"
                 aria-invalid={!!errors.disputePeriod}
-                aria-describedby={errors.disputePeriod ? "dispute-error" : undefined}
+                aria-describedby={errors.disputePeriod ? "dispute-error dispute-hint" : "dispute-hint"}
                 {...register("disputePeriod", { valueAsNumber: true })}
                 placeholder="e.g. 3"
                 className={cn(
@@ -100,7 +100,7 @@ export default function Step2Pricing() {
               />
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-gray-400">Days</span>
             </div>
-            <p className="text-xs text-gray-400 mt-1">Duration the buyer has to dispute after delivery.</p>
+            <p id="dispute-hint" className="text-xs text-gray-400 mt-1">Duration the buyer has to dispute after delivery.</p>
             {errors.disputePeriod && <p id="dispute-error" className="text-xs text-red-500 font-medium" role="alert">{errors.disputePeriod.message}</p>}
           </div>
         </div>

--- a/src/components/selling/Step3Media.tsx
+++ b/src/components/selling/Step3Media.tsx
@@ -59,6 +59,8 @@ export default function Step3Media() {
           {...getRootProps()}
           role="button"
           aria-label="Upload images by dragging and dropping or clicking"
+          aria-invalid={!!errors.media}
+          aria-describedby={errors.media ? "media-error media-hint" : "media-hint"}
           tabIndex={0}
           className={cn(
             "border-2 border-dashed rounded-xl p-12 flex flex-col items-center justify-center text-center cursor-pointer transition-all duration-300",
@@ -69,7 +71,12 @@ export default function Step3Media() {
                 : "border-gray-200 hover:border-emerald-500/50 hover:bg-gray-50"
           )}
         >
-          <input {...getInputProps()} aria-label="File upload" />
+          <input
+            {...getInputProps()}
+            aria-label="File upload"
+            aria-invalid={!!errors.media}
+            aria-describedby={errors.media ? "media-error media-hint" : "media-hint"}
+          />
           <div className={cn(
             "w-20 h-20 rounded-full flex items-center justify-center mb-6 transition-colors duration-300",
             isDragActive ? "bg-emerald-500 text-gray-900 shadow-[0_0_30px_rgba(16,185,129,0.5)]" : "bg-gray-100 text-gray-500 shadow-inner"
@@ -79,12 +86,12 @@ export default function Step3Media() {
           <h3 className="text-xl font-bold text-gray-900 mb-2">
             {isDragActive ? "Drop your files here!" : "Drag & drop your images"}
           </h3>
-          <p className="text-gray-400 text-sm max-w-sm">
+          <p id="media-hint" className="text-gray-400 text-sm max-w-sm">
             Supports JPG, PNG, GIF, and WEBP. Maximum file size 5MB. You can upload multiple files at once.
           </p>
         </div>
 
-        {errors.media && <p className="text-sm text-red-500 font-bold" role="alert">{errors.media.message?.toString()}</p>}
+        {errors.media && <p id="media-error" className="text-sm text-red-500 font-bold" role="alert">{errors.media.message?.toString()}</p>}
 
         {/* Previews Grid */}
         {previews.length > 0 && (


### PR DESCRIPTION
## Summary
- add stable error ids and aria-describedby links for login and register fields
- include pricing step hint ids alongside validation error ids
- connect media upload dropzone/input to the media hint and validation error

Closes #72

## Validation
- Verified the branch contains the expected aria-describedby and error id updates in auth and selling form files.
- Local app execution was not available in this browser-only environment.