### PR TITLE
feat: add product card loading skeletons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,34 @@ import FlashSaleSection from "@/components/home/FlashSaleSection";
 import CategoryChips from "@/components/home/CategoryChips";
 import HomeFooter from "@/components/home/HomeFooter";
 import ProductCard from "@/components/marketplace/ProductCard";
+import ProductCardSkeleton from "@/components/marketplace/ProductCardSkeleton";
 import { mockProducts } from "@/lib/mockData";
+
+async function getHomepageProducts() {
+  return mockProducts;
+}
+
+function ProductGridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+      {Array.from({ length: 10 }).map((_, index) => (
+        <ProductCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+async function ProductGrid() {
+  const products = await getHomepageProducts();
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+      {products.map((p) => (
+        <ProductCard key={p.id} product={p} />
+      ))}
+    </div>
+  );
+}
 
 export default function Home() {
   return (
@@ -35,11 +62,9 @@ export default function Home() {
               View All →
             </span>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-            {mockProducts.map((p) => (
-              <ProductCard key={p.id} product={p} />
-            ))}
-          </div>
+          <Suspense fallback={<ProductGridSkeleton />}>
+            <ProductGrid />
+          </Suspense>
         </section>
       </div>
 

--- a/src/components/marketplace/ProductCardSkeleton.tsx
+++ b/src/components/marketplace/ProductCardSkeleton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+export default function ProductCardSkeleton() {
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-lg overflow-hidden animate-pulse h-full"
+      aria-hidden="true"
+    >
+      <div className="relative h-36 bg-gray-100 flex items-center justify-center">
+        <div className="w-16 h-16 bg-gray-200 rounded-lg" />
+        <div className="absolute top-2 left-2 h-4 w-10 bg-gray-200 rounded" />
+        <div className="absolute top-2 right-2 h-4 w-12 bg-gray-200 rounded" />
+      </div>
+
+      <div className="p-3">
+        <div className="space-y-1.5 mb-2 min-h-[2.5rem]">
+          <div className="h-3 bg-gray-100 rounded w-full" />
+          <div className="h-3 bg-gray-100 rounded w-4/5" />
+        </div>
+
+        <div className="flex items-baseline gap-1.5 mb-1">
+          <div className="h-5 bg-gray-100 rounded w-16" />
+          <div className="h-3 bg-gray-100 rounded w-10" />
+        </div>
+        <div className="h-3 bg-gray-100 rounded w-20 mb-3" />
+
+        <div className="flex items-center gap-1 mb-3">
+          <div className="w-3 h-3 bg-gray-100 rounded-full" />
+          <div className="h-3 bg-gray-100 rounded w-8" />
+          <div className="h-3 bg-gray-100 rounded w-10" />
+        </div>
+
+        <div className="h-7 bg-emerald-50 border border-emerald-100 rounded-md" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a ProductCardSkeleton component that mirrors the ProductCard layout
- wrap the homepage product grid in a Suspense fallback that renders skeleton cards while products load

Closes #68

## Validation
- Verified the branch contains the new skeleton component and homepage Suspense fallback.
- Local app execution was not available in this browser-only environment.