### PR TITLE
feat: persist wishlist toggles locally

### DIFF
--- a/src/app/dashboard/wishlist/page.tsx
+++ b/src/app/dashboard/wishlist/page.tsx
@@ -1,10 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import DashboardSubnav from "@/components/dashboard/DashboardSubnav";
 import ProductCard from "@/components/marketplace/ProductCard";
 import { mockProducts } from "@/lib/mockData";
-
-const wishlistItems = mockProducts.slice(0, 6);
+import { getWishlistProducts, subscribeToWishlist } from "@/lib/wishlistStore";
 
 export default function WishlistPage() {
+  const [wishlistItems, setWishlistItems] = useState(() =>
+    getWishlistProducts(mockProducts)
+  );
+
+  useEffect(() => {
+    const syncWishlist = () => setWishlistItems(getWishlistProducts(mockProducts));
+
+    syncWishlist();
+    return subscribeToWishlist(syncWishlist);
+  }, []);
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="pt-14">

--- a/src/components/marketplace/ProductCard.tsx
+++ b/src/components/marketplace/ProductCard.tsx
@@ -1,61 +1,102 @@
+"use client";
+
 import Link from "next/link";
-import { Star } from "lucide-react";
-import { ProductMock } from "@/lib/mockData";
+import { Heart, Star } from "lucide-react";
+import type { MouseEvent } from "react";
+import { useEffect, useState } from "react";
+import type { ProductMock } from "@/lib/mockData";
+import {
+  isWishlisted,
+  subscribeToWishlist,
+  toggleWishlist,
+} from "@/lib/wishlistStore";
 
 export default function ProductCard({ product }: { product: ProductMock }) {
+  const [wishlisted, setWishlisted] = useState(false);
+
+  useEffect(() => {
+    const syncWishlistState = () => setWishlisted(isWishlisted(product.id));
+
+    syncWishlistState();
+    return subscribeToWishlist(syncWishlistState);
+  }, [product.id]);
+
+  const handleWishlistClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setWishlisted(toggleWishlist(product.id));
+  };
+
   return (
-    <Link href={`/product/${product.id}`} className="bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow group block">
-      {/* Image placeholder */}
-      <div className="relative h-36 bg-gray-100 flex items-center justify-center">
-        <div className="w-16 h-16 bg-gray-200 rounded-lg" />
-        {product.discountPercent > 0 && (
-          <span className="absolute top-2 left-2 bg-emerald-600 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-            -{product.discountPercent}%
-          </span>
-        )}
-        {product.badge === "flash" && (
-          <span className="absolute top-2 right-2 bg-orange-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-            ⚡ Flash
-          </span>
-        )}
-        {product.badge === "hot" && (
-          <span className="absolute top-2 right-2 bg-red-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-            🔥 Hot
-          </span>
-        )}
-        {product.badge === "new" && (
-          <span className="absolute top-2 right-2 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-            New
-          </span>
-        )}
-      </div>
-
-      {/* Body */}
-      <div className="p-3">
-        <p className="text-xs text-gray-600 line-clamp-2 min-h-[2.5rem] leading-snug mb-2">
-          {product.name}
-        </p>
-
-        <div className="flex items-baseline gap-1.5 mb-0.5">
-          <span className="text-base font-black text-emerald-600">${product.usdPrice}</span>
-          {product.originalUsdPrice > product.usdPrice && (
-            <span className="text-xs text-gray-400 line-through">${product.originalUsdPrice}</span>
+    <div className="relative bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow group h-full">
+      <Link href={"/product/" + product.id} className="block h-full">
+        {/* Image placeholder */}
+        <div className="relative h-36 bg-gray-100 flex items-center justify-center">
+          <div className="w-16 h-16 bg-gray-200 rounded-lg" />
+          {product.discountPercent > 0 && (
+            <span className="absolute top-2 left-2 bg-emerald-600 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+              -{product.discountPercent}%
+            </span>
+          )}
+          {product.badge === "flash" && (
+            <span className="absolute top-9 right-2 bg-orange-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+              ⚡ Flash
+            </span>
+          )}
+          {product.badge === "hot" && (
+            <span className="absolute top-9 right-2 bg-red-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+              🔥 Hot
+            </span>
+          )}
+          {product.badge === "new" && (
+            <span className="absolute top-9 right-2 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+              New
+            </span>
           )}
         </div>
-        <p className="text-[10px] text-gray-400 font-semibold mb-2">
-          ≈ {product.xlmPrice.toLocaleString()} XLM
-        </p>
 
-        <div className="flex items-center gap-1 mb-3">
-          <Star className="w-3 h-3 fill-amber-400 text-amber-400" />
-          <span className="text-[10px] font-semibold text-gray-600">{product.rating}</span>
-          <span className="text-[10px] text-gray-400">({product.reviewCount})</span>
+        {/* Body */}
+        <div className="p-3">
+          <p className="text-xs text-gray-600 line-clamp-2 min-h-[2.5rem] leading-snug mb-2">
+            {product.name}
+          </p>
+
+          <div className="flex items-baseline gap-1.5 mb-0.5">
+            <span className="text-base font-black text-emerald-600">{"$"}{product.usdPrice}</span>
+            {product.originalUsdPrice > product.usdPrice && (
+              <span className="text-xs text-gray-400 line-through">{"$"}{product.originalUsdPrice}</span>
+            )}
+          </div>
+          <p className="text-[10px] text-gray-400 font-semibold mb-2">
+            ≈ {product.xlmPrice.toLocaleString()} XLM
+          </p>
+
+          <div className="flex items-center gap-1 mb-3">
+            <Star className="w-3 h-3 fill-amber-400 text-amber-400" />
+            <span className="text-[10px] font-semibold text-gray-600">{product.rating}</span>
+            <span className="text-[10px] text-gray-400">({product.reviewCount})</span>
+          </div>
+
+          <span className="block w-full py-1.5 text-center text-[11px] font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-md group-hover:bg-emerald-600 group-hover:text-white group-hover:border-emerald-600 transition-colors">
+            + Add to Cart
+          </span>
         </div>
+      </Link>
 
-        <button className="w-full py-1.5 text-[11px] font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-md hover:bg-emerald-600 hover:text-white hover:border-emerald-600 transition-colors">
-          + Add to Cart
-        </button>
-      </div>
-    </Link>
+      <button
+        type="button"
+        aria-label={(wishlisted ? "Remove " : "Save ") + product.name + (wishlisted ? " from wishlist" : " to wishlist")}
+        aria-pressed={wishlisted}
+        onClick={handleWishlistClick}
+        className="absolute top-2 right-2 z-10 flex h-7 w-7 items-center justify-center rounded-full border border-white/80 bg-white/90 text-gray-500 shadow-sm transition-colors hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+      >
+        <Heart
+          className={[
+            "h-4 w-4",
+            wishlisted ? "fill-red-500 text-red-500" : "",
+          ].filter(Boolean).join(" ")}
+        />
+      </button>
+    </div>
   );
 }

--- a/src/lib/wishlistStore.ts
+++ b/src/lib/wishlistStore.ts
@@ -1,0 +1,78 @@
+import type { ProductMock } from "@/lib/mockData";
+
+const WISHLIST_STORAGE_KEY = "marketxpress:wishlist";
+const listeners = new Set<() => void>();
+
+function canUseStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readWishlistIds() {
+  if (!canUseStorage()) return [];
+
+  try {
+    const saved = window.localStorage.getItem(WISHLIST_STORAGE_KEY);
+    if (!saved) return [];
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeWishlistIds(ids: string[]) {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(WISHLIST_STORAGE_KEY, JSON.stringify(ids));
+}
+
+function emitWishlistChange() {
+  listeners.forEach((listener) => listener());
+}
+
+export function getWishlistIds() {
+  return readWishlistIds();
+}
+
+export function isWishlisted(productId: string) {
+  return readWishlistIds().includes(productId);
+}
+
+export function toggleWishlist(productId: string) {
+  const ids = readWishlistIds();
+  const nextIds = ids.includes(productId)
+    ? ids.filter((id) => id !== productId)
+    : [...ids, productId];
+
+  writeWishlistIds(nextIds);
+  emitWishlistChange();
+  return nextIds.includes(productId);
+}
+
+export function getWishlistProducts(products: ProductMock[]) {
+  const ids = readWishlistIds();
+  const productsById = new Map(products.map((product) => [product.id, product]));
+  return ids
+    .map((id) => productsById.get(id))
+    .filter((product): product is ProductMock => Boolean(product));
+}
+
+export function subscribeToWishlist(listener: () => void) {
+  listeners.add(listener);
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === WISHLIST_STORAGE_KEY) listener();
+  };
+
+  if (canUseStorage()) {
+    window.addEventListener("storage", handleStorage);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (canUseStorage()) {
+      window.removeEventListener("storage", handleStorage);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a small localStorage-backed wishlist store
- add a heart toggle to ProductCard with persisted pressed state
- update the wishlist dashboard page to read saved product ids instead of hardcoded mock items

Closes #70

## Validation
- Verified the branch contains ProductCard, wishlist page, and wishlistStore updates.
- Confirmed no open PR or public claim existed for #70 before submission.
- Local app execution was not available in this browser-only environment.