### PR TITLE
feat: add navbar cart drawer

### DIFF
--- a/src/components/layout/CartDrawer.tsx
+++ b/src/components/layout/CartDrawer.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { ShoppingCart, X } from "lucide-react";
+import { mockProducts } from "@/lib/mockData";
+
+interface CartDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const cartItems = mockProducts.slice(0, 3).map((product, index) => ({
+  ...product,
+  quantity: index === 0 ? 2 : 1,
+}));
+
+export default function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const subtotalUsd = cartItems.reduce(
+    (total, item) => total + item.usdPrice * item.quantity,
+    0,
+  );
+  const subtotalXlm = cartItems.reduce(
+    (total, item) => total + item.xlmPrice * item.quantity,
+    0,
+  );
+  const itemCount = cartItems.reduce((total, item) => total + item.quantity, 0);
+
+  return (
+    <div className="fixed inset-0 z-[60]" role="presentation">
+      <button
+        type="button"
+        aria-label="Close cart drawer"
+        className="absolute inset-0 bg-gray-900/40"
+        onClick={onClose}
+      />
+
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cart-drawer-title"
+        className="absolute right-0 top-0 flex h-full w-full max-w-md flex-col bg-white shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-700">
+              Cart
+            </p>
+            <h2 id="cart-drawer-title" className="text-lg font-black text-gray-900">
+              {itemCount} items ready
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Close cart drawer"
+            onClick={onClose}
+            className="rounded-full p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="space-y-3">
+            {cartItems.map((item) => (
+              <div
+                key={item.id}
+                className="flex gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3"
+              >
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-white text-emerald-700">
+                  <ShoppingCart className="h-5 w-5" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-bold text-gray-900">{item.name}</p>
+                  <p className="mt-1 text-xs text-gray-500">Sold by {item.seller}</p>
+                  <div className="mt-2 flex items-center justify-between gap-3 text-xs">
+                    <span className="rounded-full bg-white px-2 py-1 font-semibold text-gray-600">
+                      Qty {item.quantity}
+                    </span>
+                    <span className="font-black text-gray-900">
+                      {item.xlmPrice * item.quantity} XLM
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-t border-gray-200 bg-white px-5 py-4">
+          <div className="space-y-2 rounded-xl bg-gray-50 p-4">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-500">Subtotal</span>
+              <span className="font-black text-gray-900">{subtotalXlm.toLocaleString()} XLM</span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-500">USD estimate</span>
+              <span className="font-semibold text-gray-700">
+                ${subtotalUsd.toLocaleString()}
+              </span>
+            </div>
+          </div>
+
+          <Link
+            href="/dashboard/orders"
+            onClick={onClose}
+            className="mt-4 flex w-full items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-bold text-white transition-colors hover:bg-emerald-700"
+          >
+            Go to Checkout
+          </Link>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -5,12 +5,14 @@ import { usePathname } from "next/navigation";
 import { ShoppingCart, Heart, User, Store } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
+import CartDrawer from "@/components/layout/CartDrawer";
 
 export default function Navbar() {
   const pathname = usePathname();
   const { user, logout } = useAuth();
   const [query, setQuery] = useState("");
   const [accountOpen, setAccountOpen] = useState(false);
+  const [cartOpen, setCartOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
@@ -20,86 +22,95 @@ export default function Navbar() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (query.trim()) {
-      window.location.href = `/?q=${encodeURIComponent(query.trim())}`;
+      window.location.href = "/?q=" + encodeURIComponent(query.trim());
     }
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-14 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
-      {/* Wordmark */}
-      <Link href="/" className="flex items-center gap-1.5 shrink-0">
-        <span className="w-2 h-2 rounded-full bg-emerald-600" />
-        <span className="text-[15px] font-black text-gray-900 tracking-tight">MarketXpress</span>
-      </Link>
+    <>
+      <header className="fixed top-0 left-0 right-0 z-50 h-14 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+        {/* Wordmark */}
+        <Link href="/" className="flex items-center gap-1.5 shrink-0">
+          <span className="w-2 h-2 rounded-full bg-emerald-600" />
+          <span className="text-[15px] font-black text-gray-900 tracking-tight">MarketXpress</span>
+        </Link>
 
-      {/* Search */}
-      <form onSubmit={handleSearch} className="flex flex-1 max-w-xl mx-auto h-9">
-        <input
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search products, brands, categories…"
-          className="flex-1 border border-gray-200 border-r-0 rounded-l-md px-3 text-sm bg-gray-50 text-gray-900 placeholder:text-gray-400 outline-none focus:border-emerald-500 focus:bg-white transition-colors"
-        />
-        <button
-          type="submit"
-          className="bg-emerald-600 hover:bg-emerald-700 text-white px-4 rounded-r-md text-sm font-semibold transition-colors shrink-0"
-        >
-          Search
-        </button>
-      </form>
-
-      {/* Right icons */}
-      <div className="flex items-center gap-1 shrink-0">
-        {mounted && !user && (
-          <Link
-            href="/auth/register"
-            className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold rounded-md transition-colors"
+        {/* Search */}
+        <form onSubmit={handleSearch} className="flex flex-1 max-w-xl mx-auto h-9">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search products, brands, categories…"
+            className="flex-1 border border-gray-200 border-r-0 rounded-l-md px-3 text-sm bg-gray-50 text-gray-900 placeholder:text-gray-400 outline-none focus:border-emerald-500 focus:bg-white transition-colors"
+          />
+          <button
+            type="submit"
+            className="bg-emerald-600 hover:bg-emerald-700 text-white px-4 rounded-r-md text-sm font-semibold transition-colors shrink-0"
           >
-            <Store className="w-3.5 h-3.5" />
-            Sell on MX
-          </Link>
-        )}
+            Search
+          </button>
+        </form>
 
-        <Link href="/dashboard/wishlist" className="relative p-2 text-gray-500 hover:text-emerald-600 transition-colors">
-          <Heart className="w-5 h-5" />
-        </Link>
-
-        <Link href="/dashboard/orders" className="relative p-2 text-gray-500 hover:text-emerald-600 transition-colors">
-          <ShoppingCart className="w-5 h-5" />
-          <span className="absolute top-1 right-1 w-4 h-4 bg-emerald-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">3</span>
-        </Link>
-
-        {mounted && user ? (
-          <div className="relative">
-            <button
-              onClick={() => setAccountOpen((v) => !v)}
-              className="flex items-center gap-1.5 p-1.5 rounded-md hover:bg-gray-100 transition-colors"
+        {/* Right icons */}
+        <div className="flex items-center gap-1 shrink-0">
+          {mounted && !user && (
+            <Link
+              href="/auth/register"
+              className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold rounded-md transition-colors"
             >
-              <div className="w-7 h-7 rounded-full bg-emerald-600 flex items-center justify-center text-white text-xs font-bold">
-                {user.email.charAt(0).toUpperCase()}
-              </div>
-            </button>
-            {accountOpen && (
-              <div className="absolute right-0 top-10 w-48 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50">
-                <div className="px-3 py-2 border-b border-gray-100">
-                  <p className="text-xs font-semibold text-gray-900 truncate">{user.email}</p>
-                  <p className="text-[10px] text-gray-400 capitalize">{user.role.toLowerCase()}</p>
-                </div>
-                <Link href="/dashboard/orders" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">My Orders</Link>
-                <Link href="/dashboard/selling" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Selling Dashboard</Link>
-                <Link href="/dashboard/wallet" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Wallet</Link>
-                <Link href="/profile" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Profile</Link>
-                <button onClick={() => { logout(); setAccountOpen(false); }} className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50">Sign Out</button>
-              </div>
-            )}
-          </div>
-        ) : (
-          <Link href="/auth/login" className="p-2 text-gray-500 hover:text-emerald-600 transition-colors">
-            <User className="w-5 h-5" />
+              <Store className="w-3.5 h-3.5" />
+              Sell on MX
+            </Link>
+          )}
+
+          <Link href="/dashboard/wishlist" className="relative p-2 text-gray-500 hover:text-emerald-600 transition-colors">
+            <Heart className="w-5 h-5" />
           </Link>
-        )}
-      </div>
-    </header>
+
+          <button
+            type="button"
+            onClick={() => setCartOpen(true)}
+            aria-label="Open cart drawer with 3 items"
+            className="relative p-2 text-gray-500 hover:text-emerald-600 transition-colors"
+          >
+            <ShoppingCart className="w-5 h-5" />
+            <span className="absolute top-1 right-1 w-4 h-4 bg-emerald-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">3</span>
+          </button>
+
+          {mounted && user ? (
+            <div className="relative">
+              <button
+                onClick={() => setAccountOpen((v) => !v)}
+                className="flex items-center gap-1.5 p-1.5 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                <div className="w-7 h-7 rounded-full bg-emerald-600 flex items-center justify-center text-white text-xs font-bold">
+                  {user.email.charAt(0).toUpperCase()}
+                </div>
+              </button>
+              {accountOpen && (
+                <div className="absolute right-0 top-10 w-48 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50">
+                  <div className="px-3 py-2 border-b border-gray-100">
+                    <p className="text-xs font-semibold text-gray-900 truncate">{user.email}</p>
+                    <p className="text-[10px] text-gray-400 capitalize">{user.role.toLowerCase()}</p>
+                  </div>
+                  <Link href="/dashboard/orders" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">My Orders</Link>
+                  <Link href="/dashboard/selling" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Selling Dashboard</Link>
+                  <Link href="/dashboard/wallet" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Wallet</Link>
+                  <Link href="/profile" onClick={() => setAccountOpen(false)} className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Profile</Link>
+                  <button onClick={() => { logout(); setAccountOpen(false); }} className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50">Sign Out</button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <Link href="/auth/login" className="p-2 text-gray-500 hover:text-emerald-600 transition-colors">
+              <User className="w-5 h-5" />
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <CartDrawer isOpen={cartOpen} onClose={() => setCartOpen(false)} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add a right-side CartDrawer with mock cart items, item count, XLM subtotal, USD estimate, and a checkout CTA
- open the cart drawer from the Navbar cart icon instead of navigating directly to orders
- support backdrop close, close button, and Escape-to-close behavior

Closes #66

## Validation
- Confirmed #66 had 0 comments and no open PR before submission.
- Verified the branch contains CartDrawer.tsx and Navbar.tsx updates.
- Local app execution was not available in this browser-only environment.