### PR TITLE
feat: add dedicated search results route

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,72 @@
+import ProductCard from "@/components/marketplace/ProductCard";
+import { mockProducts } from "@/lib/mockData";
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string | string[] }>;
+}) {
+  const resolvedParams = await searchParams;
+  const rawQuery =
+    typeof resolvedParams.q === "string"
+      ? resolvedParams.q
+      : Array.isArray(resolvedParams.q)
+        ? resolvedParams.q[0]
+        : "";
+  const query = rawQuery.trim();
+  const searchTerms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  const filteredProducts = searchTerms.length
+    ? mockProducts.filter((product) => {
+        const searchableText = [
+          product.name,
+          product.category,
+          product.seller,
+          product.description ?? "",
+        ]
+          .join(" ")
+          .toLowerCase();
+
+        return searchTerms.every((term) => searchableText.includes(term));
+      })
+    : mockProducts;
+
+  const heading = query
+    ? `${filteredProducts.length} results for '${query}'`
+    : "Showing all products";
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 pt-24 pb-16">
+        <section className="mb-6">
+          <h1 className="text-2xl font-black text-gray-900">{heading}</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {query
+              ? "Browse products that match your search."
+              : "Start typing in the search box to filter results."}
+          </p>
+        </section>
+
+        {filteredProducts.length > 0 ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+            {filteredProducts.map((product) => (
+              <ProductCard key={product.id} product={product} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white px-6 py-10 text-center">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">No products found</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Try another keyword or browse all products.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,27 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { ShoppingCart, Heart, User, Store } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 
 export default function Navbar() {
   const pathname = usePathname();
+  const router = useRouter();
   const { user, logout } = useAuth();
   const [query, setQuery] = useState("");
   const [accountOpen, setAccountOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
 
   if (pathname.startsWith("/auth")) return null;
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (query.trim()) {
-      window.location.href = `/?q=${encodeURIComponent(query.trim())}`;
-    }
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return;
+
+    router.push(`/search?q=${encodeURIComponent(trimmedQuery)}`);
   };
 
   return (
@@ -51,7 +50,7 @@ export default function Navbar() {
 
       {/* Right icons */}
       <div className="flex items-center gap-1 shrink-0">
-        {mounted && !user && (
+        {!user && (
           <Link
             href="/auth/register"
             className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold rounded-md transition-colors"
@@ -70,7 +69,7 @@ export default function Navbar() {
           <span className="absolute top-1 right-1 w-4 h-4 bg-emerald-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">3</span>
         </Link>
 
-        {mounted && user ? (
+        {user ? (
           <div className="relative">
             <button
               onClick={() => setAccountOpen((v) => !v)}


### PR DESCRIPTION
Closes #65 
feat: add dedicated search results route

Body
add a new /search page that reads the [q](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) query param
show filtered product results with a result count heading
display a friendly empty state when no products match
update the navbar search flow to navigate to [/search?q=...](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of the home page