### PR TITLE
fix(#72): wire aria-describedby on form error messages

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -114,10 +114,11 @@ function LoginForm() {
                 onBlur={() => setTouched((p) => ({ ...p, email: true }))}
                 placeholder="name@example.com"
                 className={fieldClass("email", touched.email)}
+                aria-describedby={errors.email && touched.email ? "email-error" : undefined}
                 aria-invalid={!!errors.email}
               />
               {errors.email && touched.email && (
-                <p className="text-xs text-red-600 mt-1" role="alert">{errors.email}</p>
+                <p id="email-error" className="text-xs text-red-600 mt-1" role="alert">{errors.email}</p>
               )}
             </div>
 
@@ -138,10 +139,11 @@ function LoginForm() {
                 onBlur={() => setTouched((p) => ({ ...p, password: true }))}
                 placeholder="••••••••"
                 className={fieldClass("password", touched.password)}
+                aria-describedby={errors.password && touched.password ? "password-error" : undefined}
                 aria-invalid={!!errors.password}
               />
               {errors.password && touched.password && (
-                <p className="text-xs text-red-600 mt-1" role="alert">{errors.password}</p>
+                <p id="password-error" className="text-xs text-red-600 mt-1" role="alert">{errors.password}</p>
               )}
             </div>
 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -152,9 +152,10 @@ export default function RegisterPage() {
                   onBlur={() => setTouched((p) => ({ ...p, firstName: true }))}
                   placeholder="John"
                   className={fieldClass("firstName", touched.firstName)}
+                  aria-describedby={errors.firstName && touched.firstName ? "firstName-error" : undefined}
                 />
                 {errors.firstName && touched.firstName && (
-                  <p className="text-xs text-red-600 mt-1" role="alert">
+                  <p id="firstName-error" className="text-xs text-red-600 mt-1" role="alert">
                     {errors.firstName}
                   </p>
                 )}
@@ -171,9 +172,10 @@ export default function RegisterPage() {
                   onBlur={() => setTouched((p) => ({ ...p, lastName: true }))}
                   placeholder="Doe"
                   className={fieldClass("lastName", touched.lastName)}
+                  aria-describedby={errors.lastName && touched.lastName ? "lastName-error" : undefined}
                 />
                 {errors.lastName && touched.lastName && (
-                  <p className="text-xs text-red-600 mt-1" role="alert">
+                  <p id="lastName-error" className="text-xs text-red-600 mt-1" role="alert">
                     {errors.lastName}
                   </p>
                 )}
@@ -192,9 +194,10 @@ export default function RegisterPage() {
                 onBlur={() => setTouched((p) => ({ ...p, email: true }))}
                 placeholder="name@example.com"
                 className={fieldClass("email", touched.email)}
+                aria-describedby={errors.email && touched.email ? "email-error" : undefined}
               />
               {errors.email && touched.email && (
-                <p className="text-xs text-red-600 mt-1" role="alert">
+                <p id="email-error" className="text-xs text-red-600 mt-1" role="alert">
                   {errors.email}
                 </p>
               )}
@@ -212,9 +215,10 @@ export default function RegisterPage() {
                 onBlur={() => setTouched((p) => ({ ...p, password: true }))}
                 placeholder="Minimum 8 characters"
                 className={fieldClass("password", touched.password)}
+                aria-describedby={errors.password && touched.password ? "password-error" : undefined}
               />
               {errors.password && touched.password && (
-                <p className="text-xs text-red-600 mt-1" role="alert">
+                <p id="password-error" className="text-xs text-red-600 mt-1" role="alert">
                   {errors.password}
                 </p>
               )}

--- a/src/components/selling/Step3Media.tsx
+++ b/src/components/selling/Step3Media.tsx
@@ -69,7 +69,7 @@ export default function Step3Media() {
                 : "border-gray-200 hover:border-emerald-500/50 hover:bg-gray-50"
           )}
         >
-          <input {...getInputProps()} aria-label="File upload" />
+          <input {...getInputProps()} aria-label="File upload" aria-describedby={errors.media ? "media-error" : undefined} />
           <div className={cn(
             "w-20 h-20 rounded-full flex items-center justify-center mb-6 transition-colors duration-300",
             isDragActive ? "bg-emerald-500 text-gray-900 shadow-[0_0_30px_rgba(16,185,129,0.5)]" : "bg-gray-100 text-gray-500 shadow-inner"
@@ -84,7 +84,7 @@ export default function Step3Media() {
           </p>
         </div>
 
-        {errors.media && <p className="text-sm text-red-500 font-bold" role="alert">{errors.media.message?.toString()}</p>}
+        {errors.media && <p id="media-error" className="text-sm text-red-500 font-bold" role="alert">{errors.media.message?.toString()}</p>}
 
         {/* Previews Grid */}
         {previews.length > 0 && (


### PR DESCRIPTION
## Summary

Wires `aria-describedby` on form inputs to their associated error message elements so screen readers announce validation errors when fields receive focus.

### Changes

| File | Changes |
|------|---------|
| `src/app/auth/login/page.tsx` | Added `aria-describedby` + `id` on email and password fields |
| `src/app/auth/register/page.tsx` | Added `aria-describedby` + `id` on firstName, lastName, email, and password fields |
| `src/components/selling/Step3Media.tsx` | Added `aria-describedby` on file upload input + `id` on media error paragraph |

> **Note:** `Step1Details.tsx` and `Step2Pricing.tsx` already had `aria-describedby` correctly wired — no changes needed there.

Closes #72