### PR TITLE
fix: persist flash sale countdown across page refreshes (#69)

### DIFF
--- a/src/components/home/FlashSaleSection.tsx
+++ b/src/components/home/FlashSaleSection.tsx
@@ -5,18 +5,53 @@ import Link from "next/link";
 import ProductCard from "@/components/marketplace/ProductCard";
 import { mockProducts } from "@/lib/mockData";
 
-function useCountdown(targetSeconds: number) {
-  const [seconds, setSeconds] = useState(targetSeconds);
+const STORAGE_KEY = "marketx_flash_sale_target";
+
+function getPersistedTarget(): number | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return null;
+    const ts = Number(raw);
+    if (!Number.isFinite(ts)) return null;
+    if (ts <= Date.now()) return null;
+    return ts;
+  } catch {
+    return null;
+  }
+}
+
+function persistTarget(ts: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(ts));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+function useCountdown(durationSeconds: number) {
+  const [targetTimestamp] = useState<number>(() => {
+    const persisted = getPersistedTarget();
+    if (persisted !== null) return persisted;
+    const ts = Date.now() + durationSeconds * 1000;
+    persistTarget(ts);
+    return ts;
+  });
+
+  const [remainingMs, setRemainingMs] = useState(() =>
+    Math.max(0, targetTimestamp - Date.now())
+  );
+
   useEffect(() => {
-    const t = setInterval(
-      () => setSeconds((s) => (s > 0 ? s - 1 : targetSeconds)),
-      1000
-    );
+    const t = setInterval(() => {
+      setRemainingMs(Math.max(0, targetTimestamp - Date.now()));
+    }, 1000);
     return () => clearInterval(t);
-  }, [targetSeconds]);
-  const h = String(Math.floor(seconds / 3600)).padStart(2, "0");
-  const m = String(Math.floor((seconds % 3600) / 60)).padStart(2, "0");
-  const s = String(seconds % 60).padStart(2, "0");
+  }, [targetTimestamp]);
+
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const h = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
+  const m = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, "0");
+  const s = String(totalSeconds % 60).padStart(2, "0");
   return { h, m, s };
 }
 


### PR DESCRIPTION
## Problem

The flash sale countdown in `FlashSaleSection.tsx` calculates its remaining time as a relative duration from `Date.now()` on every mount. The current implementation:

- Passes a hardcoded duration (`4 * 3600 + 23 * 60 + 11`) to `useCountdown`
- The hook initializes `seconds` state to this value on every render
- Refreshing the page resets the countdown to the full duration instead of continuing from where it was

## Solution

Persist the absolute target end timestamp to `localStorage` so the countdown survives page refreshes.

### Changes in `src/components/home/FlashSaleSection.tsx`

**New helpers:**
- `getPersistedTarget()` — reads the stored target timestamp from `localStorage` (key: `marketx_flash_sale_target`), validates it is a finite number still in the future, returns it or `null`
- `persistTarget()` — writes the computed target timestamp to `localStorage`

**Refactored `useCountdown` hook:**
- On mount, checks `localStorage` first
  - If a valid future target exists → uses it (countdown continues across refreshes)
  - If none exists or stored value is expired → computes a fresh target (`Date.now() + durationSeconds * 1000`), persists it, uses that
- On each tick: recalculates `remainingMs = Math.max(0, targetTimestamp - Date.now())` instead of decrementing a counter
- Uses `useState` lazy initializer to compute the target once on mount — no overwriting on every render or tick

### Edge cases handled

| Case | Behavior |
|------|----------|
| localStorage unavailable (private browsing, disabled) | try/catch returns null, in-memory fallback |
| Corrupted/non-numeric value | isFinite check → recompute |
| Expired stored target | ts <= Date.now() → recompute |
| Multiple tabs | Each reads localStorage on mount, same target |
| Sale window ends | Countdown stops at 00:00:00 (no reset loop) |

### Follow-up
When a `saleId` prop is available, scope the key to `marketx_flash_sale_target-${saleId}` so different sale windows don't collide.

Closes #69
